### PR TITLE
Remove "scripts" folder to unblock shipit from universe

### DIFF
--- a/scripts/jest/custom-transformer.js
+++ b/scripts/jest/custom-transformer.js
@@ -1,9 +1,0 @@
-// @flow
-
-const path = require('path');
-const babelJest = require('babel-jest');
-
-module.exports = babelJest.createTransformer(
-  // $FlowAllowDynamicImport
-  require(path.join(__dirname, '..', '..', '.babelrc.js')),
-);


### PR DESCRIPTION
Since `scripts` folder is now ignored too, it has to be removed as well to enable shipit: https://github.com/adeira/universe/commit/fb7a077a5c3f2595941c5c711b8051a42db84009/checks?check_suite_id=357359740